### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM dockerhub/library/python:3.7
-# FROM python:3.7
+FROM dockerhub/library/python:3.9.12
+# FROM python:3.9.12
 RUN pip install django==3.1.7 psycopg2==2.8.6
 
 COPY ./app /app


### PR DESCRIPTION
範本Python-Django的image有GPG key過期的問題，解法：
FROM dockerhub/library/python:3.7 -> FROM dockerhub/library/python:3.9.12